### PR TITLE
FIX: octokit error with trailing slash in repo name

### DIFF
--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -9,6 +9,7 @@ module DiscourseGithubPlugin
       SiteSetting.github_badges_repos.split("|").each do |link|
         name = link.match(/https?:\/\/github.com\/(.+)/).captures.first
         name.gsub!(/\.git$/, "")
+        name.gsub!(/\/$/, "") # Remove trailing '/'
         repos << find_or_create_by!(name: name)
       end
       repos

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseGithubPlugin::GithubRepo do
+
+  it "strips .git from url" do
+    SiteSetting.set("github_badges_repos", "https://github.com/discourse/discourse.git")
+    repo = DiscourseGithubPlugin::GithubRepo.repos.first
+    expect(repo.name).to eq ("discourse/discourse")
+  end
+
+  it "strips trailing slash from url" do
+    SiteSetting.set("github_badges_repos", "https://github.com/discourse/discourse/")
+    repo = DiscourseGithubPlugin::GithubRepo.repos.first
+    expect(repo.name).to eq ("discourse/discourse")
+  end
+end
+


### PR DESCRIPTION
If the repo url specified in site settings has a trailing slash octokit
will raise an 'invalid_repository' error.

This fix strips the trailing slash from any urls specified in
`github_badges_repos` and adds a model test for this as well as a test
for stripping `.git` from the url.