### PR TITLE
FIX: Remove update_attributes! which is deprecated in Rails 6.0.0

### DIFF
--- a/app/lib/github_badges.rb
+++ b/app/lib/github_badges.rb
@@ -28,7 +28,7 @@ module DiscourseGithubPlugin
             if commits_count >= threshold && badge.enabled? && SiteSetting.enable_badges
               BadgeGranter.grant(badge, user)
               if user.title.blank? && as_title
-                user.update_attributes!(title: badge.name)
+                user.update!(title: badge.name)
               end
             end
           end


### PR DESCRIPTION
An easy fix to remove the warning in Rails 6.0.0