### PR TITLE
[WIP] FIX: Use top-level namespace for base classes

### DIFF
--- a/app/jobs/regular/create_github_linkback.rb
+++ b/app/jobs/regular/create_github_linkback.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jobs
-  class CreateGithubLinkback < Jobs::Base
+  class CreateGithubLinkback < ::Jobs::Base
     def execute(args)
       return unless SiteSetting.enable_discourse_github_plugin?
       return unless SiteSetting.github_linkback_enabled?

--- a/app/jobs/regular/replace_github_non_permalinks.rb
+++ b/app/jobs/regular/replace_github_non_permalinks.rb
@@ -6,7 +6,7 @@ require 'uri'
 
 module Jobs
 
-  class ReplaceGithubNonPermalinks < Jobs::Base
+  class ReplaceGithubNonPermalinks < ::Jobs::Base
     sidekiq_options queue: 'low'
 
     def execute(args)


### PR DESCRIPTION
Zeitwerk is failing when we are searching for Jobs::Onceoff and Jobs::Base without going back to the top-level namespace (this is correlated to the fact that we got Onceoff base class and module with the same name). 

I noticed that in plugins we are using sometimes :: and sometimes not and that gives me comfort that this change will not break anything.

Travis error: https://travis-ci.org/discourse/discourse/jobs/585072364