### PR TITLE
DEV: Don't post multiple linkbacks for the same PR

### DIFF
--- a/app/lib/github_linkback.rb
+++ b/app/lib/github_linkback.rb
@@ -24,7 +24,7 @@ class GithubLinkback
     !!(SiteSetting.github_linkback_enabled? &&
       SiteSetting.enable_discourse_github_plugin? &&
       @post.present? &&
-      @post.raw =~ /github/ &&
+      @post.raw =~ /github\.com/ &&
       Guardian.new.can_see?(@post) &&
       @post.topic.visible?)
   end

--- a/app/lib/github_linkback.rb
+++ b/app/lib/github_linkback.rb
@@ -40,23 +40,28 @@ class GithubLinkback
 
     result = {}
     PrettyText.extract_links(@post.cooked).map(&:url).each do |l|
-      l = l.split('#')[0]
-      next if @post.custom_fields[GithubLinkback.field_for(l)].present?
-
       if l =~ /https?:\/\/github\.com\/([^\/]+)\/([^\/]+)\/commit\/([0-9a-f]+)/
-        project = "#{Regexp.last_match[1]}/#{Regexp.last_match[2]}"
-        if is_allowed_project_link?(projects, project)
-          link = Link.new(Regexp.last_match[0], project, :commit)
-          link.sha = Regexp.last_match[3]
-          result[link.url] = link
-        end
+        url, org, repo, sha = Regexp.last_match.to_a
+        project = "#{org}/#{repo}"
+
+        next if result[url]
+        next if @post.custom_fields[GithubLinkback.field_for(url)].present?
+        next unless is_allowed_project_link?(projects, project)
+
+        link = Link.new(url, project, :commit)
+        link.sha = sha
+        result[url] = link
       elsif l =~ /https?:\/\/github.com\/([^\/]+)\/([^\/]+)\/pull\/(\d+)/
-        project = "#{Regexp.last_match[1]}/#{Regexp.last_match[2]}"
-        if is_allowed_project_link?(projects, project)
-          link = Link.new(Regexp.last_match[0], project, :pr)
-          link.pr_number = Regexp.last_match[3].to_i
-          result[link.url] = link
-        end
+        url, org, repo, pr_number = Regexp.last_match.to_a
+        project = "#{org}/#{repo}"
+
+        next if result[url]
+        next if @post.custom_fields[GithubLinkback.field_for(url)].present?
+        next unless is_allowed_project_link?(projects, project)
+
+        link = Link.new(url, project, :pr)
+        link.pr_number = pr_number.to_i
+        result[url] = link
       end
     end
     result.values

--- a/spec/lib/github_linkback_spec.rb
+++ b/spec/lib/github_linkback_spec.rb
@@ -37,7 +37,7 @@ describe GithubLinkback do
   end
 
   context "#should_enqueue?" do
-    let(:post_without_link) { Fabricate.build(:post) }
+    let(:post_without_link) { Fabricate.build(:post, raw: "Hello github!") }
 
     let(:post_with_link) do
       Fabricate.build(:post, raw: 'https://github.com/discourse/discourse/commit/5be9bee2307dd517c26e6ef269471aceba5d5acf')
@@ -53,7 +53,7 @@ describe GithubLinkback do
       expect(GithubLinkback.new(nil).should_enqueue?).to eq(false)
     end
 
-    it "returns false when the post doesn't have the word github in it" do
+    it "returns false when the post doesn't have the `github.com` in it" do
       SiteSetting.github_linkback_enabled = true
       expect(GithubLinkback.new(post_without_link).should_enqueue?).to eq(false)
     end

--- a/spec/lib/github_linkback_spec.rb
+++ b/spec/lib/github_linkback_spec.rb
@@ -6,6 +6,7 @@ describe GithubLinkback do
   let(:github_commit_link) { "https://github.com/discourse/discourse/commit/76981605fa10975e2e7af457e2f6a31909e0c811" }
   let(:github_commit_link_with_anchor) { "#{github_commit_link}#anchor" }
   let(:github_pr_link) { "https://github.com/discourse/discourse/pull/701" }
+  let(:github_pr_files_link) { "https://github.com/discourse/discourse/pull/701/files" }
   let(:github_pr_link_wildcard) { "https://github.com/discourse/discourse-github-linkback/pull/3" }
 
   let(:post) do
@@ -25,6 +26,8 @@ describe GithubLinkback do
         https://github.com/eviltrout/tis-100/commit/e22b23f354e3a1c31bc7ad37a6a309fd6daf18f4
 
         #{github_pr_link}
+
+        #{github_pr_files_link}
 
         i have no idea what i'm linking back to
 


### PR DESCRIPTION
If a post contained any variants of PR URL like:

https://github.com/CvX/discourse/pull/8203/commits
https://github.com/CvX/discourse/pull/8203/files
https://github.com/CvX/discourse/pull/8203/checks

…(and with new new github onebox that's the case) the plugin would create an extra linkback every time you'd run the job (i.e. the job was unintentionally non-idempotent)