### PR TITLE
Allow different badge repo format and validate setting

### DIFF
--- a/app/lib/github_badges_repo_setting_validator.rb
+++ b/app/lib/github_badges_repo_setting_validator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class GithubBadgesRepoSettingValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val.blank?
+    val.split("|").all? do |repo|
+      repo.match?(DiscourseGithubPlugin::GithubRepo::VALID_URL_BASED_REPO_REGEX) || \
+        repo.match?(DiscourseGithubPlugin::GithubRepo::VALID_USER_BASED_REPO_REGEX)
+    end
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.invalid_badge_repo")
+  end
+end

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -3,7 +3,7 @@
 module DiscourseGithubPlugin
   class GithubRepo < ActiveRecord::Base
     VALID_URL_BASED_REPO_REGEX = /https?:\/\/github.com\/(.+)/
-    VALID_USER_BASED_REPO_REGEX = /[\w\-\_]+\/[\w\-\_]+/
+    VALID_USER_BASED_REPO_REGEX = Octokit::Repository::NAME_WITH_OWNER_PATTERN
 
     has_many :commits, foreign_key: :repo_id, class_name: :GithubCommit, dependent: :destroy
 

--- a/app/models/github_repo.rb
+++ b/app/models/github_repo.rb
@@ -2,18 +2,30 @@
 
 module DiscourseGithubPlugin
   class GithubRepo < ActiveRecord::Base
+    VALID_URL_BASED_REPO_REGEX = /https?:\/\/github.com\/(.+)/
+    VALID_USER_BASED_REPO_REGEX = /[\w\-\_]+\/[\w\-\_]+/
+
     has_many :commits, foreign_key: :repo_id, class_name: :GithubCommit, dependent: :destroy
 
     def self.repos
       repos = []
       SiteSetting.github_badges_repos.split("|").each do |link|
-        next unless link =~ /https?:\/\/github.com\/(.+)/
-        name = Regexp.last_match[1]
+        name = match_name_from_setting(link)
+        next if name.blank?
         name.gsub!(/\.git$/, "")
         name.gsub!(/\/$/, "") # Remove trailing '/'
         repos << find_or_create_by!(name: name)
       end
       repos
+    end
+
+    def self.match_name_from_setting(repo)
+      if repo =~ VALID_URL_BASED_REPO_REGEX
+        Regexp.last_match[1]
+      elsif repo =~ VALID_USER_BASED_REPO_REGEX
+        repo_name = Regexp.last_match[0]
+        repo.match(/https?:/).blank? ? repo_name : nil
+      end
     end
   end
 end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,6 +11,9 @@ en:
     github_silver_badge_min_commits: "Minumum number of commits for silver badge"
     github_gold_badge_min_commits: "Minumum number of commits for gold badge"
 
+    errors:
+      invalid_badge_repo: "You must provide a GitHub URL or the repository name in the format github_user/repository_name"
+
   github_linkback:
     commit_template: |
       This commit has been mentioned on **%{title}**. There might be relevant details there:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,7 @@ plugins:
   github_badges_repos:
     default: ''
     type: list
+    validator: "GithubBadgesRepoSettingValidator"
   github_permalinks_enabled:
     default: false
   github_permalinks_exclude:

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,6 +11,9 @@ gem 'addressable', '2.7.0'
 gem 'sawyer', '0.8.2'
 gem 'octokit', '4.14.0'
 
+# Site setting validators must be loaded before initialize
+require_relative "app/lib/github_badges_repo_setting_validator.rb"
+
 enabled_site_setting :enable_discourse_github_plugin
 enabled_site_setting_filter :github
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -2,7 +2,7 @@
 
 # name: discourse-github
 # about: Github Linkback, Github Badges, Github Permalinks
-# version: 0.2
+# version: 0.3
 # authors: Robin Ward, Sam Saffron
 # url: https://github.com/discourse/discourse-github
 

--- a/spec/lib/github_badges_repo_setting_validator_spec.rb
+++ b/spec/lib/github_badges_repo_setting_validator_spec.rb
@@ -15,7 +15,7 @@ describe GithubBadgesRepoSettingValidator do
     end
 
     context "when a github repo in the format user/repo is provided" do
-      let(:value) { "discourse/discourse_github" }
+      let(:value) { "discourse/discourse-github" }
 
       it "is ok" do
         expect(subject.valid_value?(value)).to eq(true)
@@ -31,7 +31,7 @@ describe GithubBadgesRepoSettingValidator do
     end
 
     context "when multiple valid settings are provided" do
-      let(:value) { "discourse/discourse_github|https://github.com/discourse/discourse/" }
+      let(:value) { "discourse/discourse-github|https://github.com/discourse/discourse/" }
 
       it "is ok" do
         expect(subject.valid_value?(value)).to eq(true)
@@ -39,7 +39,7 @@ describe GithubBadgesRepoSettingValidator do
     end
 
     context "when multiple valid settings with one invalid setting is provided" do
-      let(:value) { "discourse/discourse_github|https://github.com/discourse/discourse/|bad-dog" }
+      let(:value) { "discourse/discourse-github|https://github.com/discourse/discourse/|bad-dog" }
 
       it "is not ok" do
         expect(subject.valid_value?(value)).to eq(false)

--- a/spec/lib/github_badges_repo_setting_validator_spec.rb
+++ b/spec/lib/github_badges_repo_setting_validator_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GithubBadgesRepoSettingValidator do
+  subject { described_class.new }
+
+  describe "#valid_value?" do
+    context "when a github URL is provided" do
+      let(:value) { "https://github.com/discourse/discourse/" }
+
+      it "is ok" do
+        expect(subject.valid_value?(value)).to eq(true)
+      end
+    end
+
+    context "when a github repo in the format user/repo is provided" do
+      let(:value) { "discourse/discourse_github" }
+
+      it "is ok" do
+        expect(subject.valid_value?(value)).to eq(true)
+      end
+    end
+
+    context "when a github repo name by itself is provided" do
+      let(:value) { "some-repo" }
+
+      it "is not ok" do
+        expect(subject.valid_value?(value)).to eq(false)
+      end
+    end
+
+    context "when multiple valid settings are provided" do
+      let(:value) { "discourse/discourse_github|https://github.com/discourse/discourse/" }
+
+      it "is ok" do
+        expect(subject.valid_value?(value)).to eq(true)
+      end
+    end
+
+    context "when multiple valid settings with one invalid setting is provided" do
+      let(:value) { "discourse/discourse_github|https://github.com/discourse/discourse/|bad-dog" }
+
+      it "is not ok" do
+        expect(subject.valid_value?(value)).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -16,19 +16,10 @@ describe DiscourseGithubPlugin::GithubRepo do
     expect(repo.name).to eq ("discourse/discourse")
   end
 
-  it "doesn't raise an error when the site setting doesn't contain a github URL" do
-    SiteSetting.github_badges_repos = "https://eviltrout.com/discourse/discourse/"
-    expect(DiscourseGithubPlugin::GithubRepo.repos).to be_blank
-  end
-
   it "doesn't raise an error when the site setting follows the user/repo format" do
     SiteSetting.github_badges_repos = "discourse/discourse-github"
     repo = DiscourseGithubPlugin::GithubRepo.repos.first
     expect(repo.name).to eq ("discourse/discourse-github")
-
-    SiteSetting.github_badges_repos = "discourse/discourse_github"
-    repo = DiscourseGithubPlugin::GithubRepo.repos.first
-    expect(repo.name).to eq ("discourse/discourse_github")
 
     SiteSetting.github_badges_repos = "discourse/somerepo_with-numbers7"
     repo = DiscourseGithubPlugin::GithubRepo.repos.first

--- a/spec/models/github_repo_spec.rb
+++ b/spec/models/github_repo_spec.rb
@@ -20,4 +20,18 @@ describe DiscourseGithubPlugin::GithubRepo do
     SiteSetting.github_badges_repos = "https://eviltrout.com/discourse/discourse/"
     expect(DiscourseGithubPlugin::GithubRepo.repos).to be_blank
   end
+
+  it "doesn't raise an error when the site setting follows the user/repo format" do
+    SiteSetting.github_badges_repos = "discourse/discourse-github"
+    repo = DiscourseGithubPlugin::GithubRepo.repos.first
+    expect(repo.name).to eq ("discourse/discourse-github")
+
+    SiteSetting.github_badges_repos = "discourse/discourse_github"
+    repo = DiscourseGithubPlugin::GithubRepo.repos.first
+    expect(repo.name).to eq ("discourse/discourse_github")
+
+    SiteSetting.github_badges_repos = "discourse/somerepo_with-numbers7"
+    repo = DiscourseGithubPlugin::GithubRepo.repos.first
+    expect(repo.name).to eq ("discourse/somerepo_with-numbers7")
+  end
 end


### PR DESCRIPTION
This fix is needed because the logs have had the following error on a few instances:

```
Job exception: "$REPO_NAME" is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys.
```

This was happening because we were not validating the site setting for `github_badges_repos`, and allowing the user to put in any value here, so some people were just putting in a repo name instead of a URL.

We now allow repos in the formats:

* https://github.com/discourse/discourse.git
* https://github.com/discourse/discourse
* discourse/discourse

And we also have a proper setting validator class and tests.