### PR TITLE
FIX: Disable GitHub badges if invalid octokit credentials found

### DIFF
--- a/app/lib/commits_populator.rb
+++ b/app/lib/commits_populator.rb
@@ -151,13 +151,13 @@ module DiscourseGithubPlugin
 
     def disable_github_badges_and_inform_admin
       SiteSetting.github_badges_enabled = false
-      site_admin_username = User.where(admin: true).human_users.limit(1).pluck(:username).first
+      site_admin_usernames = User.where(admin: true).human_users.order('last_seen_at DESC').limit(10).pluck(:username)
       PostCreator.create!(
         Discourse.system_user,
         title: I18n.t("github_commits_populator.errors.invalid_octokit_credentials_pm_title"),
         raw: I18n.t("github_commits_populator.errors.invalid_octokit_credentials_pm", base_path: Discourse.base_path),
         archetype: Archetype.private_message,
-        target_usernames: site_admin_username,
+        target_usernames: site_admin_usernames,
         skip_validations: true
       )
     end

--- a/app/lib/github_linkback_access_token_setting_validator.rb
+++ b/app/lib/github_linkback_access_token_setting_validator.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+class GithubLinkbackAccessTokenSettingValidator
+  def initialize(opts = {})
+    @opts = opts
+  end
+
+  def valid_value?(val)
+    return true if val.blank?
+    client = Octokit::Client.new(access_token: val, per_page: 1)
+    DiscourseGithubPlugin::GithubRepo.repos.each do |repo|
+      client.branches(repo.name)
+    end
+    true
+  rescue Octokit::Unauthorized
+    false
+  end
+
+  def error_message
+    I18n.t("site_settings.errors.invalid_github_linkback_access_token")
+  end
+end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -13,6 +13,7 @@ en:
 
     errors:
       invalid_badge_repo: "You must provide a GitHub URL or the repository name in the format github_user/repository_name"
+      invalid_github_linkback_access_token: "You must provide a valid GitHub linkback access token which has access to the badge repositories you have provided."
 
   github_linkback:
     commit_template: |

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,12 +1,12 @@
 en:
   site_settings:
     enable_discourse_github_plugin: "Enable the discourse-github plugin"
-    github_linkback_enabled: "Link github issues back to forum discussions"
+    github_linkback_enabled: "Link GitHub issues back to forum discussions"
     github_linkback_projects: "List of projects to link back from"
     github_linkback_access_token: "A valid access token for the user who will post the linkback and for counting commits/contributions to grant badges. See <a href=\"https://meta.discourse.org/t/99895\">here</a> for instructions on how to get a token."
-    github_permalinks_enabled: "Enable Github permalink overwrites"
+    github_permalinks_enabled: "Enable GitHub permalink overwrites"
     github_permalinks_exclude: "Filename or directory that should be excluded from permalink overwrites. Provide only filename or full path: user/repository/optional-directory/filename"
-    github_badges_enabled: "Enable github badges"
+    github_badges_enabled: "Enable GitHub badges"
     github_badges_repos: 'URLs of the GitHub repos to scan for contributions and commits'
     github_silver_badge_min_commits: "Minumum number of commits for silver badge"
     github_gold_badge_min_commits: "Minumum number of commits for gold badge"
@@ -27,4 +27,4 @@ en:
   github_commits_populator:
     errors:
       invalid_octokit_credentials_pm_title: "Action required for discourse-github plugin"
-      invalid_octokit_credentials_pm: "The GitHub credentials provided to the discourse-github plugin are invalid. The GitHub badges setting has been disabled, and commits will no longer be populated until the issue is resolved.<br/><br/>Check your github linkback access token setting to ensure the token is correct at <a href=\"%{base_path}/admin/site_settings/category/plugins?filter=github\">the discourse-github Site Settings</a>."
+      invalid_octokit_credentials_pm: "The GitHub credentials provided to the discourse-github plugin are invalid. The \"github badges enabled\" site setting has been disabled, and commits will no longer be populated until the issue is resolved.<br/><br/>Check your \"github linkback access token\" site setting to ensure the token is correct and has permission to all repos via <a href=\"%{base_path}/admin/site_settings/category/plugins?filter=GitHub\">discourse-github Site Settings</a>."

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -23,3 +23,7 @@ en:
       This pull request has been mentioned on **%{title}**. There might be relevant details there:
 
       %{post_url}
+  github_commits_populator:
+    errors:
+      invalid_octokit_credentials_pm_title: "Action required for discourse-github plugin"
+      invalid_octokit_credentials_pm: "The GitHub credentials provided to the discourse-github plugin are invalid. The GitHub badges setting has been disabled, and commits will no longer be populated until the issue is resolved.<br/><br/>Check your github linkback access token setting to ensure the token is correct at <a href=\"%{base_path}/admin/site_settings/category/plugins?filter=github\">the discourse-github Site Settings</a>."

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -8,6 +8,7 @@ plugins:
   github_linkback_access_token:
     default: ''
     secret: true
+    validator: "GithubLinkbackAccessTokenSettingValidator"
   github_badges_enabled:
     default: false
   github_badges_repos:

--- a/plugin.rb
+++ b/plugin.rb
@@ -11,6 +11,7 @@ gem 'octokit', '4.14.0'
 
 # Site setting validators must be loaded before initialize
 require_relative "app/lib/github_badges_repo_setting_validator.rb"
+require_relative "app/lib/github_linkback_access_token_setting_validator.rb"
 
 enabled_site_setting :enable_discourse_github_plugin
 enabled_site_setting_filter :github

--- a/spec/lib/commits_populator_spec.rb
+++ b/spec/lib/commits_populator_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseGithubPlugin::CommitsPopulator do
+  let(:repo) { DiscourseGithubPlugin::GithubRepo.new(name: 'discourse/discourse') }
+  let!(:site_admin) { Fabricate(:admin) }
+  subject { described_class.new(repo) }
+
+  before do
+    SiteSetting.github_badges_enabled = true
+  end
+
+  context "when invalid credentials have been provided for octokit" do
+    before do
+      Octokit::Client.any_instance.expects(:branches).raises(Octokit::Unauthorized)
+    end
+
+    it "disables github badges and sends a PM to the admin of the site to inform them" do
+      subject.populate!
+      expect(SiteSetting.github_badges_enabled).to eq(false)
+      sent_pm = Post.joins(:topic).includes(:topic).where('topics.archetype = ?', Archetype.private_message).last
+      expect(sent_pm.topic.allowed_users.include?(site_admin)).to eq(true)
+      expect(sent_pm.topic.title).to eq(I18n.t("github_commits_populator.errors.invalid_octokit_credentials_pm_title"))
+      expect(sent_pm.raw).to eq(I18n.t("github_commits_populator.errors.invalid_octokit_credentials_pm", base_path: Discourse.base_path))
+    end
+  end
+
+  context "if some other octokit error is raised" do
+    before do
+      Octokit::Client.any_instance.expects(:branches).raises(Octokit::Error)
+    end
+
+    it "simply logs the error and does nothing else" do
+      subject.populate!
+      expect(SiteSetting.github_badges_enabled).to eq(true)
+    end
+  end
+
+  context "if github_badges_enabled is false" do
+    before do
+      SiteSetting.github_badges_enabled = false
+    end
+
+    it "early returns before attempting to execute any of the commit fetching, because the plugin likely disabled itself" do
+      Octokit::Client.any_instance.expects(:branches).never
+      subject.populate!
+    end
+  end
+end

--- a/spec/lib/commits_populator_spec.rb
+++ b/spec/lib/commits_populator_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 describe DiscourseGithubPlugin::CommitsPopulator do
   let(:repo) { DiscourseGithubPlugin::GithubRepo.new(name: 'discourse/discourse') }
-  let!(:site_admin) { Fabricate(:admin) }
+  let!(:site_admin1) { Fabricate(:admin) }
+  let!(:site_admin2) { Fabricate(:admin) }
   subject { described_class.new(repo) }
 
   before do
@@ -20,7 +21,8 @@ describe DiscourseGithubPlugin::CommitsPopulator do
       subject.populate!
       expect(SiteSetting.github_badges_enabled).to eq(false)
       sent_pm = Post.joins(:topic).includes(:topic).where('topics.archetype = ?', Archetype.private_message).last
-      expect(sent_pm.topic.allowed_users.include?(site_admin)).to eq(true)
+      expect(sent_pm.topic.allowed_users.include?(site_admin1)).to eq(true)
+      expect(sent_pm.topic.allowed_users.include?(site_admin2)).to eq(true)
       expect(sent_pm.topic.title).to eq(I18n.t("github_commits_populator.errors.invalid_octokit_credentials_pm_title"))
       expect(sent_pm.raw).to eq(I18n.t("github_commits_populator.errors.invalid_octokit_credentials_pm", base_path: Discourse.base_path))
     end

--- a/spec/lib/github_linkback_access_token_setting_validator_spec.rb
+++ b/spec/lib/github_linkback_access_token_setting_validator_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe GithubLinkbackAccessTokenSettingValidator do
+  subject { described_class.new }
+
+  let(:value) { SecureRandom.hex(10) }
+
+  describe "#valid_value?" do
+    context "when an Octokit::Unauthorized error is raised, meaning the access token cannot access a repo" do
+      before do
+        setup_repos
+        Octokit::Client.any_instance.expects(:branches).raises(Octokit::Unauthorized)
+      end
+
+      it "should fail" do
+        expect(subject.valid_value?(value)).to eq(false)
+      end
+    end
+
+    context "when no Octokit::Unauthorized error is raised" do
+      it "should pass, without repos defined" do
+        expect(subject.valid_value?(value)).to eq(true)
+      end
+
+      context "when there are repos defined" do
+        before do
+          setup_repos
+          Octokit::Client.any_instance.expects(:branches).returns([])
+        end
+
+        it "should pass if all the repos are accessible" do
+          expect(subject.valid_value?(value)).to eq(true)
+        end
+      end
+    end
+  end
+
+  def setup_repos
+    SiteSetting.github_badges_repos = "discourse/discourse"
+    DiscourseGithubPlugin::GithubRepo.repos
+  end
+end


### PR DESCRIPTION
A fix/mitigation for this error from the logs:

```
Octokit::Unauthorized: GET https://api.github.com/repos/PSAppDeployToolkit/PSAppDeployToolkit/branches?per_page=100: 401 - Bad credentials // See: https://developer.github.com/v3
```

When we are iterating through all the badge repos to populate commits, if the `github_linkback_access_token` site setting is not correct we get the `Octokit::Unauthorized` error.

To deal with this we:

* Disable the `github_badges_enabled` site setting when encountering the `Octokit::Unauthorized` error.
* Send a PM to the last 10 seen site admins informing them of the issue and what they can do to correct it.
* Validate when saving the `github_linkback_access_token` site setting. We iterate through all the badge repos defined and check whether the token can access the repo by getting a single branch from the repo. If we encounter the `Octokit::Unauthorized` error for any repo then we stop the whole show with this message:

![image](https://user-images.githubusercontent.com/920448/71651409-e9c3e680-2d68-11ea-899f-a128c22891f1.png)

This is the PM sent to the admin:

![image](https://user-images.githubusercontent.com/920448/71651492-aae26080-2d69-11ea-9de7-8b10fc44042a.png)
