### PR TITLE
FIX: Disable GitHub badges if a repository is "Not Found"

### DIFF
--- a/app/lib/commits_populator.rb
+++ b/app/lib/commits_populator.rb
@@ -161,7 +161,7 @@ module DiscourseGithubPlugin
       "discourse-github-back-commit-#{@repo.name}"
     end
 
-    def disable_github_badges_and_inform_admin(title, raw)
+    def disable_github_badges_and_inform_admin(title:, raw:)
       SiteSetting.github_badges_enabled = false
       site_admin_usernames = User.where(admin: true).human_users.order('last_seen_at DESC').limit(10).pluck(:username)
       PostCreator.create!(

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -32,3 +32,11 @@ en:
     errors:
       invalid_octokit_credentials_pm_title: "Action required for discourse-github plugin"
       invalid_octokit_credentials_pm: "The GitHub credentials provided to the discourse-github plugin are invalid. The \"github badges enabled\" site setting has been disabled, and commits will no longer be populated until the issue is resolved.<br/><br/>Check your \"github linkback access token\" site setting to ensure the token is correct and has permission to all repos via <a href=\"%{base_path}/admin/site_settings/category/plugins?filter=GitHub\">discourse-github Site Settings</a>."
+      repository_not_found_pm_title: "Action required for discourse-github plugin"
+      repository_not_found_pm: |
+        A repository specified in the discourse-github plugin returned a "Not Found"
+        error: %{repo_name}
+
+        Badges will not be awarded until the name is corrected in
+        <a href=\"%{base_path}/admin/site_settings/category/plugins?filter=GitHub\">discourse-github Site Settings</a>
+        and "github_badges_enabled" is turned back on.


### PR DESCRIPTION
When we encounter Octokit::NotFound --

- Disable the github_badges_enabled site setting
- Send a PM to the 10 most recently active admins