### PR TITLE
FIX: InvalidRepository not being rescued and disabling badges job

### DIFF
--- a/app/lib/commits_populator.rb
+++ b/app/lib/commits_populator.rb
@@ -41,13 +41,6 @@ module DiscourseGithubPlugin
       end
     rescue Octokit::Error => err
       case err
-      when Octokit::InvalidRepository
-        disable_github_badges_and_inform_admin(
-          title: I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm_title"),
-          raw: I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm",
-                      repo_name: @repo.name),
-        )
-        Rails.logger.warn("Disabled github_badges_enabled site setting due to invalid repository identifier")
       when Octokit::NotFound
         disable_github_badges_and_inform_admin(
           title: I18n.t("github_commits_populator.errors.repository_not_found_pm_title"),
@@ -65,6 +58,13 @@ module DiscourseGithubPlugin
       else
         Rails.logger.warn("#{err.class}: #{err.message}")
       end
+    rescue Octokit::InvalidRepository => err
+      disable_github_badges_and_inform_admin(
+        title: I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm_title"),
+        raw: I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm",
+                    repo_name: @repo.name),
+      )
+      Rails.logger.warn("Disabled github_badges_enabled site setting due to invalid repository identifier")
     end
 
     private

--- a/spec/lib/commits_populator_spec.rb
+++ b/spec/lib/commits_populator_spec.rb
@@ -28,7 +28,7 @@ describe DiscourseGithubPlugin::CommitsPopulator do
     end
   end
 
-  context "when invalid credentials have been provided for octokit" do
+  context "when the repository is not found" do
     before do
       Octokit::Client.any_instance.expects(:branches).raises(Octokit::NotFound)
     end
@@ -41,6 +41,22 @@ describe DiscourseGithubPlugin::CommitsPopulator do
       expect(sent_pm.topic.allowed_users.include?(site_admin2)).to eq(true)
       expect(sent_pm.topic.title).to eq(I18n.t("github_commits_populator.errors.repository_not_found_pm_title"))
       expect(sent_pm.raw).to eq(I18n.t("github_commits_populator.errors.repository_not_found_pm", base_path: Discourse.base_path))
+    end
+  end
+
+  context "when the repository identifier is invalid" do
+    before do
+      Octokit::Client.any_instance.expects(:branches).raises(Octokit::InvalidRepository)
+    end
+
+    it "disables github badges and sends a PM to the admin of the site to inform them" do
+      subject.populate!
+      expect(SiteSetting.github_badges_enabled).to eq(false)
+      sent_pm = Post.joins(:topic).includes(:topic).where('topics.archetype = ?', Archetype.private_message).last
+      expect(sent_pm.topic.allowed_users.include?(site_admin1)).to eq(true)
+      expect(sent_pm.topic.allowed_users.include?(site_admin2)).to eq(true)
+      expect(sent_pm.topic.title).to eq(I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm_title"))
+      expect(sent_pm.raw).to eq(I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm", base_path: Discourse.base_path))
     end
   end
 


### PR DESCRIPTION
* The `InvalidRepository` error class is not a subclass of `Octokit::Error` so it was not being caught in our rescue block https://github.com/octokit/octokit.rb/blob/14bb1a1d4fec8d2250dc6f6b9cb2d446a0332d58/lib/octokit/error.rb#L316