### PR TITLE
Fix translation not found error for Github badges error messages

### DIFF
--- a/app/lib/commits_populator.rb
+++ b/app/lib/commits_populator.rb
@@ -45,7 +45,8 @@ module DiscourseGithubPlugin
         disable_github_badges_and_inform_admin(
           title: I18n.t("github_commits_populator.errors.repository_not_found_pm_title"),
           raw: I18n.t("github_commits_populator.errors.repository_not_found_pm",
-                      repo_name: @repo.name),
+                      repo_name: @repo.name,
+                      base_path: Discourse.base_path),
         )
         Rails.logger.warn("Disabled github_badges_enabled site setting due to repository Not Found error ")
       when Octokit::Unauthorized
@@ -62,7 +63,8 @@ module DiscourseGithubPlugin
       disable_github_badges_and_inform_admin(
         title: I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm_title"),
         raw: I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm",
-                    repo_name: @repo.name),
+                    repo_name: @repo.name,
+                    base_path: Discourse.base_path),
       )
       Rails.logger.warn("Disabled github_badges_enabled site setting due to invalid repository identifier")
     end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -38,7 +38,7 @@ en:
         They should be specified as `user/repo`.
 
         Badges will not be awarded until the name is corrected in
-        <a href=\"%{base_path}/admin/site_settings/category/plugins?filter=GitHub\">discourse-github Site Settings</a>
+        <a href="%{base_path}/admin/site_settings/category/plugins?filter=GitHub">discourse-github Site Settings</a>
         and "github_badges_enabled" is turned back on.
       repository_not_found_pm_title: "Action required for discourse-github plugin"
       repository_not_found_pm: |
@@ -46,7 +46,7 @@ en:
         error: %{repo_name}
 
         Badges will not be awarded until the name is corrected in
-        <a href=\"%{base_path}/admin/site_settings/category/plugins?filter=GitHub\">discourse-github Site Settings</a>
+        <a href="%{base_path}/admin/site_settings/category/plugins?filter=GitHub">discourse-github Site Settings</a>
         and "github_badges_enabled" is turned back on.
       invalid_octokit_credentials_pm_title: "Action required for discourse-github plugin"
       invalid_octokit_credentials_pm: |

--- a/spec/lib/commits_populator_spec.rb
+++ b/spec/lib/commits_populator_spec.rb
@@ -40,7 +40,7 @@ describe DiscourseGithubPlugin::CommitsPopulator do
       expect(sent_pm.topic.allowed_users.include?(site_admin1)).to eq(true)
       expect(sent_pm.topic.allowed_users.include?(site_admin2)).to eq(true)
       expect(sent_pm.topic.title).to eq(I18n.t("github_commits_populator.errors.repository_not_found_pm_title"))
-      expect(sent_pm.raw).to eq(I18n.t("github_commits_populator.errors.repository_not_found_pm", base_path: Discourse.base_path))
+      expect(sent_pm.raw).to eq(I18n.t("github_commits_populator.errors.repository_not_found_pm", repo_name: repo.name, base_path: Discourse.base_path).strip)
     end
   end
 
@@ -56,7 +56,7 @@ describe DiscourseGithubPlugin::CommitsPopulator do
       expect(sent_pm.topic.allowed_users.include?(site_admin1)).to eq(true)
       expect(sent_pm.topic.allowed_users.include?(site_admin2)).to eq(true)
       expect(sent_pm.topic.title).to eq(I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm_title"))
-      expect(sent_pm.raw).to eq(I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm", base_path: Discourse.base_path))
+      expect(sent_pm.raw).to eq(I18n.t("github_commits_populator.errors.repository_identifier_invalid_pm", repo_name: repo.name, base_path: Discourse.base_path).strip)
     end
   end
 


### PR DESCRIPTION
Calls to `disable_github_badges_and_inform_admin` are returning a missing translation error because the `base_url` placeholder is not set. The specs are passing because both the `sent_pm` and the translation from the spec file were returning `translation missing: en.github_commits_populator.errors.repository_not_found_pm`.

This PR adds the `base_path` to the calls that are made when a repo isn't found, or when the repo identifier is invalid. It also makes the links in the PM clickable. Previously the link in the `invalid_octokit_credentials_pm` PM was clickable, but the links returned with the `repository_identifier_invalid_pm` and `repository_not_found_pm` PMs were escaped.