### PR TITLE
FIX: Improve contributors detection

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
 inherit_gem:
   rubocop-discourse: default.yml
+AllCops:
+  Exclude:
+    - 'gems/**/*'

--- a/db/migrate/20201210032852_discourse_github_rebuild_git_history.rb
+++ b/db/migrate/20201210032852_discourse_github_rebuild_git_history.rb
@@ -2,6 +2,10 @@
 
 class DiscourseGithubRebuildGitHistory < ActiveRecord::Migration[6.0]
   def up
+    # the table will be repopulated the next time the `UpdateJob` runs.
+    # This will not have any noticeable effects on the site because
+    # this table is merely used to grant the committer and contributor
+    # badges. Deleting commits will not cause users to lose badges.
     execute "DELETE FROM github_commits"
   end
 

--- a/db/migrate/20201210032852_discourse_github_rebuild_git_history.rb
+++ b/db/migrate/20201210032852_discourse_github_rebuild_git_history.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DiscourseGithubRebuildGitHistory < ActiveRecord::Migration[6.0]
+  def up
+    execute "DELETE FROM github_commits"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end


### PR DESCRIPTION
This plugin ships with 2 types of badges: Contributor and Committer.
Currently, these badges are granted by replicating the git history of the
configured repositories in the database using Github's REST API, and
then looking up users by the emails on the commits and hand out badges.

A commit is considered a 'contribution' if it comes from a pull request
that was not created and merged by the same user. The commits endpoint
of Github's REST API doesn't include whether a commit comes from a PR or
not. So, our only way to detect contributions is to compare the
`committer` and `author` fields of the commit object that we get from
the API. This method worked fairly well up until December 2019 when
Github changed something that made the `committer` always be set to
`GitHub` and not the user who merged the pull request.

So, this commit replaces the REST API with GraphQL which allows us to
include pull request data (if any) with each commit object. This gives
us a reliable way for detecting contributions.