### PR TITLE
FIX: No data or error is returned when auth fails

### DIFF
--- a/app/lib/commits_populator.rb
+++ b/app/lib/commits_populator.rb
@@ -87,6 +87,7 @@ module DiscourseGithubPlugin
         QUERY
         response = @client.post("/graphql", { query: query }.to_json)
         raise GraphQLError, response.errors.inspect if response.errors
+        raise GraphQLError, response.message if !response.data
         @data = response.data
       end
     end


### PR DESCRIPTION
GitHub's GraphQL does not return an error if authentication fails, but
it does not return data either, which is later causing issues.