### PR TITLE
Add setting to limit number of linkbacks per post

### DIFF
--- a/app/lib/github_linkback.rb
+++ b/app/lib/github_linkback.rb
@@ -96,6 +96,8 @@ class GithubLinkback
 
     DistributedMutex.synchronize("github_linkback_#{@post.id}") do
       links = github_links
+      return [] if links.length() > SiteSetting.github_linkback_maximum_links
+
       links.each do |link|
         case link.type
         when :commit

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,6 +4,7 @@ en:
     github_linkback_enabled: "Link GitHub issues back to forum discussions"
     github_linkback_projects: "List of projects to link back from"
     github_linkback_access_token: 'A valid access token for the user who will post the linkback and for counting commits/contributions to grant badges. See <a href="https://meta.discourse.org/t/99895">here</a> for instructions on how to get a token.'
+    github_linkback_maximum_links: "Maximum number of linkbacks to create from one single post. When a post contains more links, none is created."
     github_permalinks_enabled: "Enable GitHub permalink overwrites"
     github_permalinks_exclude: "Filename or directory that should be excluded from permalink overwrites. Provide only filename or full path: user/repository/optional-directory/filename"
     github_badges_enabled: "Enable GitHub badges"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,9 @@ plugins:
     default: ""
     secret: true
     validator: "GithubLinkbackAccessTokenSettingValidator"
+  github_linkback_maximum_links:
+    default: 25
+    min: 1
   github_badges_enabled:
     default: false
   github_badges_repos:

--- a/spec/lib/github_linkback_spec.rb
+++ b/spec/lib/github_linkback_spec.rb
@@ -212,6 +212,27 @@ describe GithubLinkback do
         field = GithubLinkback.field_for(github_pr_link_wildcard)
         expect(post.custom_fields[field]).to be_present
       end
+
+      it "should create linkback for <= SiteSetting.github_linkback_maximum_links urls" do
+        SiteSetting.github_linkback_maximum_links = 2
+        post = Fabricate(:post, raw: "#{github_pr_link} #{github_issue_link}")
+        links = GithubLinkback.new(post).create
+        expect(links.size).to eq(2)
+      end
+
+      it "should skip linkback for > SiteSetting.github_linkback_maximum_links urls" do
+        SiteSetting.github_linkback_maximum_links = 1
+        post = Fabricate(:post, raw: "#{github_pr_link} #{github_issue_link}")
+        links = GithubLinkback.new(post).create
+        expect(links.size).to eq(0)
+      end
+
+      it "should create linkback for <= SiteSetting.github_linkback_maximum_links unique urls" do
+        SiteSetting.github_linkback_maximum_links = 1
+        post = Fabricate(:post, raw: "#{github_pr_link} #{github_pr_link} #{github_pr_link}")
+        links = GithubLinkback.new(post).create
+        expect(links.size).to eq(1)
+      end
     end
   end
 


### PR DESCRIPTION
I am moderating a discourse forum for an open-source app ([AntennaPod](https://github.com/AntennaPod/AntennaPod)). We use the linkback feature to connect the forum with GitHub - which is a great feature.

For every release, we prepare a manual list of changes in that version, linking to the respective GitHub PR (example [here](https://forum.antennapod.org/t/antennapod-2-4-release-notes/1300)). Whenever this happens, followers of the project are flooded with dozens of emails. For example, this is how my inbox looks like (notice that the emails were all sent at the same time). In total, I received around 100 emails from the linkback plugin today.

<img width="300" src="https://user-images.githubusercontent.com/5811634/132261810-eeec1caa-d6a2-4d61-bebb-78ea8d621b1a.png" />

This PR introduces a setting to define the maximum number of linkbacks to create from a single post. When the number of links is larger than the setting, linking back is probably not helpful anyway. In that case, the plugin therefore generates no link at all.