### PR TITLE
FIX: Check if badge can be used as a title

### DIFF
--- a/app/lib/github_badges.rb
+++ b/app/lib/github_badges.rb
@@ -67,7 +67,7 @@ module DiscourseGithubPlugin
           @badges.each do |badge, as_title, threshold|
             if commits_count >= threshold && badge.enabled? && SiteSetting.enable_badges
               BadgeGranter.grant(badge, user)
-              if user.title.blank? && as_title
+              if badge.allow_title? && user.title.blank? && as_title
                 user.update!(title: badge.name)
               end
             end

--- a/spec/lib/github_badges_spec.rb
+++ b/spec/lib/github_badges_spec.rb
@@ -125,5 +125,18 @@ describe DiscourseGithubPlugin::GithubBadges do
       # does not grant badges to staged users
       expect(staged_user.badges.first).to eq(nil)
     end
+
+    it 'does not update user title if badge is not allowed to be used as a title' do
+      DiscourseGithubPlugin::GithubBadges.grant!
+      silver_comitter_badge = Badge.find_by(name: DiscourseGithubPlugin::GithubBadges::COMMITER_BADGE_NAME_SILVER)
+
+      silver_comitter_badge.update!(enabled: true)
+      DiscourseGithubPlugin::GithubBadges.grant!
+      expect(silver_user.reload.title).to eq(nil)
+
+      silver_comitter_badge.update!(allow_title: true)
+      DiscourseGithubPlugin::GithubBadges.grant!
+      expect(silver_user.reload.title).to eq(silver_comitter_badge.name)
+    end
   end
 end


### PR DESCRIPTION
The GitHub badge granter GithubBadges::Granter updated user titles
automatically ignoring the allow_title attribute of the badge. This
caused some users to have titles that are not normally allowed.

The user title automatically disappears when Jobs::BadgeGrant runs and
calls BadgeGranter.revoke_ungranted_titles!, so no further action is
required.