### PR TITLE
DEV: Update octokit

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -7,7 +7,7 @@
 # url: https://github.com/discourse/discourse-github
 
 gem 'sawyer', '0.8.2'
-gem 'octokit', '4.21.0'
+gem 'octokit', '4.22.0'
 
 # Site setting validators must be loaded before initialize
 require_relative "app/lib/github_badges_repo_setting_validator.rb"


### PR DESCRIPTION
Fixes a Faraday auth deprecation warning