### PR TITLE
DEV: Fix plugin tests following a core change

### DIFF
--- a/spec/jobs/replace_github_non_permalinks_spec.rb
+++ b/spec/jobs/replace_github_non_permalinks_spec.rb
@@ -57,6 +57,8 @@ describe Jobs::ReplaceGithubNonPermalinks do
     end
 
     it "works with multiple github urls in the post" do
+      stub_request(:get, github_permanent_url).to_return(status: 200, body: "")
+      stub_request(:get, github_permanent_url2.gsub(/#.+$/, "")).to_return(status: 200, body: "")
       post = Fabricate(:post, raw: "#{github_url} #{github_url2} htts://github.com")
       job.execute(post_id: post.id)
       post.reload


### PR DESCRIPTION
There was an `Exception` rescue in core that was hiding an error raised during a spec of this plugin. Core now surfaces exceptions in the test environment which causes the spec to fail now.

Related to https://github.com/discourse/discourse/pull/16150.