### PR TITLE
UX: Update badge icon

### DIFF
--- a/app/lib/github_badges.rb
+++ b/app/lib/github_badges.rb
@@ -125,6 +125,7 @@ module DiscourseGithubPlugin
           BADGE_NAME_BRONZE,
           description: "Contributed an accepted pull request",
           badge_type_id: 3,
+          default_icon: "fab-git-alt",
         )
 
       silver =
@@ -132,6 +133,7 @@ module DiscourseGithubPlugin
           BADGE_NAME_SILVER,
           description: "Contributed 25 accepted pull requests",
           badge_type_id: 2,
+          default_icon: "fab-git-alt",
         )
 
       gold =
@@ -139,6 +141,7 @@ module DiscourseGithubPlugin
           BADGE_NAME_GOLD,
           description: "Contributed 250 accepted pull requests",
           badge_type_id: 1,
+          default_icon: "fab-git-alt",
         )
 
       [bronze, silver, gold]

--- a/db/migrate/20230227050148_update_github_badge_icons.rb
+++ b/db/migrate/20230227050148_update_github_badge_icons.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class UpdateGithubBadgeIcons < ActiveRecord::Migration[7.0]
+  def change
+    badges = [
+      DiscourseGithubPlugin::GithubBadges::BADGE_NAME_BRONZE,
+      DiscourseGithubPlugin::GithubBadges::BADGE_NAME_SILVER,
+      DiscourseGithubPlugin::GithubBadges::BADGE_NAME_GOLD,
+      DiscourseGithubPlugin::GithubBadges::COMMITTER_BADGE_NAME_BRONZE,
+      DiscourseGithubPlugin::GithubBadges::COMMITTER_BADGE_NAME_SILVER,
+      DiscourseGithubPlugin::GithubBadges::COMMITTER_BADGE_NAME_GOLD,
+    ]
+    execute <<~SQL
+      UPDATE badges
+      SET icon = 'fab-git-alt'
+      WHERE
+        name IN (#{badges.map { |b| "'#{b}'" }.join(",")})
+    SQL
+  end
+end

--- a/db/migrate/20230227050148_update_github_badge_icons.rb
+++ b/db/migrate/20230227050148_update_github_badge_icons.rb
@@ -15,6 +15,7 @@ class UpdateGithubBadgeIcons < ActiveRecord::Migration[7.0]
       SET icon = 'fab-git-alt'
       WHERE
         name IN (#{badges.map { |b| "'#{b}'" }.join(",")})
+        AND icon = 'fa-certificate'
     SQL
   end
 end


### PR DESCRIPTION

Essentially changing defaults to fab-git

<img width="111" alt="Screenshot 2023-02-27 at 5 24 31 PM" src="https://user-images.githubusercontent.com/1555215/221524625-2ce4d2e1-cdd8-41e8-9660-3c8c2e97f8e0.png">

<img width="105" alt="Screenshot 2023-02-27 at 5 24 46 PM" src="https://user-images.githubusercontent.com/1555215/221524674-7a72e7d2-d575-4577-8715-2319a81f4a29.png">

Related: https://meta.discourse.org/t/badges-on-meta/256289
