### PR TITLE
DEV: Replace deprecated queue_jobs site setting in tests

### DIFF
--- a/spec/jobs/replace_github_non_permalinks_spec.rb
+++ b/spec/jobs/replace_github_non_permalinks_spec.rb
@@ -44,7 +44,7 @@ describe Jobs::ReplaceGithubNonPermalinks do
 
   describe "#execute" do
     before do
-      SiteSetting.queue_jobs = false
+      Jobs.run_immediately!
       SiteSetting.github_permalinks_enabled = true
     end
 


### PR DESCRIPTION
### What is this change?

The `#queue_jobs=` method on site settings has been [deprecated](https://github.com/discourse/discourse/commit/1b65469b64e9e569fed67ae11f1dd9ee37702f5c) and replaced by `Jobs.run_later!` and `Jobs.run_immediately!`. This PR replaces usages in this plugin so we can remove the fallback in core.

The fallback used in core for reference:

https://github.com/discourse/discourse/blob/main/app/models/site_setting.rb#L109-L115