### PR TITLE
DEV: Change settings root from plugins: to discourse_github

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,3 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_github: "Discourse GitHub"
+en:
   replace_github_link:
     edit_reason: "Github link was replaced with a permanent link"

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_github:
   enable_discourse_github_plugin: true
   github_linkback_enabled:
     default: false


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.