### PR TITLE
DEV: remove extra en root key from client.en.yml

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -4,6 +4,5 @@ en:
       site_settings:
         categories:
           discourse_github: "Discourse GitHub"
-en:
   replace_github_link:
     edit_reason: "Github link was replaced with a permanent link"


### PR DESCRIPTION
Fixes the broken text of the "Discourse GitHub" nav link on the site settings page.

<img width="520" alt="Screenshot 2023-11-16 at 2 10 09 AM" src="https://github.com/discourse/discourse-github/assets/22733864/2d9419f6-e8b2-4dc8-8b29-f4813872636a">
