### PR TITLE
FIX: Use Guardian.basic_user instead of new (anon)

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,2 +1,3 @@
+< 3.2.0.beta4-dev: 8ed826a133d8a9b96bae1fbab16783b1f74402b4
 3.1.999: 8aa068d56ef010cecaabd50657e7753f4bbecc1f
 

--- a/app/lib/github_linkback.rb
+++ b/app/lib/github_linkback.rb
@@ -23,7 +23,7 @@ class GithubLinkback
     !!(
       SiteSetting.github_linkback_enabled? && SiteSetting.enable_discourse_github_plugin? &&
         @post.present? && @post.post_type == Post.types[:regular] && @post.raw =~ /github\.com/ &&
-        Guardian.new.can_see?(@post) && @post.topic.visible?
+        Guardian.basic_user.can_see?(@post) && @post.topic.visible?
     )
   end
 


### PR DESCRIPTION
c.f. discourse/discourse@de983796e1b66aa2ab039a4fb6e32cec8a65a098

There will soon be additional login_required checks
for Guardian, and the intent of many checks by automated
systems is better fulfilled by using BasicUser, which
simulates a logged in TL0 forum user, rather than an
anon user.
