### PR TITLE
Revert "FIX: Use Guardian.basic_user instead of new (anon) (#97)"

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,2 @@
-< 3.2.0.beta4-dev: 8ed826a133d8a9b96bae1fbab16783b1f74402b4
 3.1.999: 8aa068d56ef010cecaabd50657e7753f4bbecc1f
 

--- a/app/lib/github_linkback.rb
+++ b/app/lib/github_linkback.rb
@@ -23,7 +23,7 @@ class GithubLinkback
     !!(
       SiteSetting.github_linkback_enabled? && SiteSetting.enable_discourse_github_plugin? &&
         @post.present? && @post.post_type == Post.types[:regular] && @post.raw =~ /github\.com/ &&
-        Guardian.basic_user.can_see?(@post) && @post.topic.visible?
+        Guardian.new.can_see?(@post) && @post.topic.visible?
     )
   end
 


### PR DESCRIPTION
This reverts commit c049ff489f677c827883048053f217bb37b8305e.

c.f. https://github.com/discourse/discourse/pull/24742