### PR TITLE
Add option to use a custom field for GitHub user matching

### DIFF
--- a/app/lib/github_badges.rb
+++ b/app/lib/github_badges.rb
@@ -97,7 +97,7 @@ module DiscourseGithubPlugin
 
       bronze, silver, gold = committer_badges
 
-      granter = GithubBadges::Granter.new(emails)
+      granter = GithubBadges::Granter.new(emails, SiteSetting.custom_user_field)
       granter.add_badge(bronze, as_title: false, threshold: 1)
       granter.add_badge(silver, as_title: true, threshold: 25)
       granter.add_badge(gold, as_title: true, threshold: 1000)
@@ -113,7 +113,7 @@ module DiscourseGithubPlugin
 
       bronze, silver, gold = contributor_badges
 
-      granter = GithubBadges::Granter.new(emails)
+      granter = GithubBadges::Granter.new(emails, SiteSetting.custom_user_field)
       granter.add_badge(bronze, as_title: false, threshold: 1)
       granter.add_badge(
         silver,

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -29,3 +29,5 @@ discourse_github:
   github_gold_badge_min_commits:
     default: 250
     min: 1
+  github_user_custom_field:
+    default: ""


### PR DESCRIPTION
We use [DiscourseConnect](https://meta.discourse.org/t/13045?silent=true) to integrate with our SSO which already has user's github user name. 

We trust this information, and pass it along to discourse as a custom user field that cannot be edited.

This updates the plugin to optionally look at a custom user field if it is set.


Caveats: I'm not a ruby dev so I don't really know what I am doing but we are actively testing this in production.

